### PR TITLE
Add GuildDetails lookup.

### DIFF
--- a/guildwars2api/client.py
+++ b/guildwars2api/client.py
@@ -1,6 +1,6 @@
 import requests
 
-from guildwars2api.resources import Events, EventNames, MapNames, WorldNames, Matches, MatchDetails, ObjectiveNames, Items, ItemDetails, Recipes, RecipeDetails
+from guildwars2api.resources import GuildDetails, Events, EventNames, MapNames, WorldNames, Matches, MatchDetails, ObjectiveNames, Items, ItemDetails, Recipes, RecipeDetails
 
 
 class GuildWars2API(object):
@@ -35,6 +35,7 @@ class GuildWars2API(object):
         self.item_details = self._prepare(ItemDetails)
         self.recipes = self._prepare(Recipes)
         self.recipe_details = self._prepare(RecipeDetails)
+        self.guild_details = self._prepare(GuildDetails)
 
     def _prepare(self, resource):
         return resource(self.options, self.session)

--- a/guildwars2api/resources.py
+++ b/guildwars2api/resources.py
@@ -184,3 +184,12 @@ class RecipeDetails(Resource):
         """
         return super(RecipeDetails, self).get(recipe_id=recipe_id)
 
+
+class GuildDetails(Resource):
+    api_class = 'guild_details'
+
+    def get(self, guild_name):
+        """
+        :param guild_name: The name of the guild to get details for
+        """
+        return super(GuildDetails, self).get(guild_name=guild_name)


### PR DESCRIPTION
Adds a guild lookup by name.  To test:

from guildwars2api import client

api = client.GuildWars2API()
api.guild_details.get('Colorful Metaphor')

Should return something like this:
Out[3]:
{u'emblem': {u'background_color_id': 473,
  u'background_id': 20,
  u'flags': [],
  u'foreground_id': 146,
  u'foreground_primary_color_id': 4,
  u'foreground_secondary_color_id': 93},
 u'guild_id': u'35131675-2AD7-4897-9545-BAC9539D7C95',
 u'guild_name': u'Colorful Metaphor',
 u'tag': u'CM'}
